### PR TITLE
Fix fivem-appearance outfitmenu

### DIFF
--- a/mt-clothingbag/client.lua
+++ b/mt-clothingbag/client.lua
@@ -56,7 +56,7 @@ RegisterNetEvent('mt-clothing:client:AbrirMenu', function()
     if Config.ClothingMenu == 'qb-clothing' then
         TriggerEvent('qb-clothing:client:openOutfitMenu')
     elseif Config.ClothingMenu == 'fivem-appearance' then
-        TriggerEvent('fivem-appearance:pickNewOutfit')
+        TriggerEvent('qb-clothing:client:openOutfitMenu')
     end
 end)
 


### PR DESCRIPTION
So after speaking to Fivem-appearance dev in discord regarding this issue he confirmed the script has backwards compatible events meaning it's not necessary for an entirely new event to trigger the outfit menu to open, you just use the same qb-clothing trigger and it will open, doing this fixes the option for fivem-appearance also making it completely redundant but hey it makes people feel like they've set it to the right option at least and should anything change in the future regarding this easy change then