### PR TITLE
Fix Duplicate Event Names

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -3,7 +3,7 @@ local QBCore = exports['qb-core']:GetCoreObject()
 QBCore.Functions.CreateUseableItem("clothing_bag", function(source, item)
     local Player = QBCore.Functions.GetPlayer(source)
 	if Player.Functions.GetItemBySlot(item.slot) ~= nil then
-        TriggerClientEvent('mt-clothingbag:client:openBag', source)
+        TriggerClientEvent('mt-clothingbag:client:putBag', source)
     end
 end)
 


### PR DESCRIPTION
There were two events with the same name so the script was not working as it should used to.